### PR TITLE
Fix Cloudflare 403 + New Seasonal Feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ https://kuryana.vercel.app/search/q/{yourquery}
 ```
 https://kuryana.vercel.app/id/{mydramalist-slug}
 ```
+- [Get seasonal drama](https://kuryana.vercel.app/seasonal/)
+```
+https://kuryana.vercel.app/seasonal/{year}/{quarter}
+```
 
 ## NOTE:
 All Requests and SCRAPED Datas are not cached by Vercel or the API itself.

--- a/api/main.py
+++ b/api/main.py
@@ -3,6 +3,9 @@ from starlette.status import HTTP_404_NOT_FOUND, HTTP_500_INTERNAL_SERVER_ERROR
 
 from api.utils import search_func, fetch_func
 
+# bypassing cloudflare anti-bot
+import cloudscraper
+
 app = FastAPI()
 
 
@@ -42,3 +45,13 @@ async def fetch(drama_id: str, response: Response):
         return fetch
 
     return fetch
+
+
+# get seasonal drama list -- official api available, use it with cloudflare bypass 
+@app.get("/seasonal/{year}/{quarter}")
+async def mdlSeasonal(year: int, quarter: int):
+    scraper = cloudscraper.create_scraper()
+    return scraper.post("https://mydramalist.com/v1/quarter_calendar", data = { "quarter": quarter, "year": year }).json()
+    # year -> ex. ... / 2019 / 2020 / 2021 / ...
+    # quarter -> every 3 months (Jan-Mar=1, Apr-Jun=2, Jul-Sep=3, Oct-Dec=4)
+    # --- seasonal information --- winter --- spring --- summer --- fall ---

--- a/api/parser.py
+++ b/api/parser.py
@@ -1,4 +1,8 @@
-import httpx
+# import httpx
+
+# bypassing cloudflare anti-bot
+import cloudscraper
+
 from bs4 import BeautifulSoup
 from datetime import datetime
 
@@ -47,8 +51,12 @@ class Parser:
     # website getter / page source grabber
     async def scrape(self):
         try:
-            async with httpx.AsyncClient() as client:
-                resp = await client.get(self.website_def(), timeout=None)
+            # async with httpx.AsyncClient() as client:
+            #     resp = await client.get(self.website_def(), timeout=None)
+
+            # bypassing cloudflare anti-bot
+            scraper = cloudscraper.create_scraper()
+            resp = scraper.get(self.website_def())
 
             # set the main soup var
             self.soup = BeautifulSoup(resp.text, "lxml")

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ sniffio==1.2.0
 soupsieve==2.2.1
 starlette==0.13.6
 typing-extensions==3.7.4.3
+cloudscraper==1.2.56


### PR DESCRIPTION
Hi, hopefully you check this.

Recently, we can't access MyDramaList pages externally (using http request from script or bot like backend do) always return 403 - forbidden.
So i've change `httpx` to using `cloudscraper` that can bypass cloudflare anti ddos (browser check integrity &/ captcha) which already include python `request` library.

I also add new route for listing current airing drama or movie using official seasonal api.
The route is `/seasonal/{year}/{quarter}`
year => number, for example 2021
quarter => number too, but only 1-4 (every 3 months)

More info commented in the code.
Thanks.