### PR TITLE
Feature/adriano

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,16 +67,36 @@ GET /id/{mydramalist-slug}/episodes
 GET /id/{mydramalist-slug}/reviews
 ```
 
+- Get DRAMA Photos
+
+```sh
+GET /id/{mydramalist-slug}/photos
+```
+
 - Get Person(People) Info
 
 ```sh
 GET /people/{people-id}
 ```
 
-- Get seasonal drama
+- Get Person(People) Photos
+
+```sh
+GET /people/{people-id}/photos
+```
+
+- Get seasonal dramas by quarter
 
 ```sh
 GET /seasonal/{year}/{quarter}
+```
+
+> `quarter`: `1` = Jan–Mar · `2` = Apr–Jun · `3` = Jul–Sep · `4` = Oct–Dec
+
+- Get current week episode schedule
+
+```sh
+GET /schedule
 ```
 
 - Get Lists
@@ -204,7 +224,13 @@ if __name__ == "__main__":
 
 ### Dev Server
 
-Start development server.
+Start development server with hot reload.
+
+```sh
+uv run dev
+```
+
+Or using FastAPI CLI directly:
 
 ```sh
 uv run fastapi dev

--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,1 +1,7 @@
 MYDRAMALIST_WEBSITE = "https://mydramalist.com/"  # MyDramaList.com
+
+
+def main() -> None:
+    import uvicorn
+
+    uvicorn.run("app.main:app", reload=True)

--- a/app/handlers/fetch.py
+++ b/app/handlers/fetch.py
@@ -836,6 +836,72 @@ class FetchList(BaseFetch):
         self._get_main_container()
 
 
+class FetchPhotos(BaseFetch):
+    def __init__(self, soup: BeautifulSoup, query: str, code: int, ok: bool) -> None:
+        super().__init__(soup, query, code, ok)
+
+    def _get_main_container(self) -> None:
+        if self.soup is None:
+            return
+
+        container = self.soup.find("div", class_="app-body")
+        if container is None:
+            return
+
+        _film_title = container.find("h1", class_="film-title")
+        if _film_title is not None:
+            self.info["title"] = _film_title.get_text().strip()
+
+        photos: List[Dict[str, Any]] = []
+
+        _photos_ul = container.find("ul", class_=re.compile(r"photos"))
+        if _photos_ul is None:
+            _photos_ul = container.find("div", class_=re.compile(r"photos"))
+
+        if _photos_ul is not None:
+            items = _photos_ul.find_all("li") or _photos_ul.find_all("div", recursive=False)
+            for item in items:
+                _a = item.find("a")
+                _img = item.find("img")
+
+                photo: Dict[str, Any] = {}
+
+                if _a is not None:
+                    href = str(_a.get("href", "")).strip()
+                    if href:
+                        photo["link"] = urljoin(MYDRAMALIST_WEBSITE, href)
+
+                if _img is not None:
+                    for attr in self._img_attrs:
+                        if _img.has_attr(attr):
+                            thumb = str(_img[attr])
+                            photo["image"] = thumb
+                            photo["full_image"] = thumb.replace("m.jpg", "f.jpg")
+                            break
+
+                if photo:
+                    photos.append(photo)
+
+        # fallback: collect all anchored images inside the body that look like photo entries
+        if not photos:
+            for _a in container.find_all("a", href=re.compile(r"/photos/")):
+                _img = _a.find("img")
+                photo = {"link": urljoin(MYDRAMALIST_WEBSITE, str(_a.get("href", "")).strip())}
+                if _img is not None:
+                    for attr in self._img_attrs:
+                        if _img.has_attr(attr):
+                            thumb = str(_img[attr])
+                            photo["image"] = thumb
+                            photo["full_image"] = thumb.replace("m.jpg", "f.jpg")
+                            break
+                photos.append(photo)
+
+        self.info["photos"] = photos
+
+    def _get(self) -> None:
+        self._get_main_container()
+
+
 class FetchEpisodes(BaseFetch):
     def __init__(self, soup, query, code, ok):
         super().__init__(soup, query, code, ok)

--- a/app/main.py
+++ b/app/main.py
@@ -1,17 +1,31 @@
-from typing import Any, Dict
+from typing import Any, Dict, List
 
 import primp
 from fastapi import FastAPI, Response
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.lib.msgspec_json import MsgSpecJSONResponse
+from app.schemas import (
+    CastResponse,
+    DramaResponse,
+    DramalistResponse,
+    EpisodesResponse,
+    ErrorResponse,
+    ListResponse,
+    PersonResponse,
+    PhotosResponse,
+    ReviewsResponse,
+    ScheduleResponse,
+    SearchResponse,
+    SeasonalDrama,
+)
 from app.utils import fetch_func, search_func
 
 app = FastAPI(
     title="Kuryana",
+    description="A simple MyDramaList.com scraper API.",
     default_response_class=MsgSpecJSONResponse,
 )
-
 
 app.add_middleware(
     CORSMiddleware,
@@ -21,13 +35,23 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
+_error_responses = {
+    400: {"model": ErrorResponse, "description": "Page error returned by MDL"},
+    404: {"model": ErrorResponse, "description": "Not found"},
+}
+
 
 @app.get("/")
 async def index() -> Dict[str, Any]:
     return {"message": "A Simple and Basic MDL Scraper API"}
 
 
-@app.get("/search/q/{query}")
+@app.get(
+    "/search/q/{query}",
+    response_model=SearchResponse,
+    tags=["search"],
+    summary="Search dramas and people",
+)
 async def search(query: str, response: Response) -> Dict[str, Any]:
     code, r = await search_func(query=query)
 
@@ -35,7 +59,13 @@ async def search(query: str, response: Response) -> Dict[str, Any]:
     return r
 
 
-@app.get("/id/{drama_id}")
+@app.get(
+    "/id/{drama_id}",
+    response_model=DramaResponse,
+    tags=["drama"],
+    summary="Drama details",
+    responses=_error_responses,
+)
 async def fetch(drama_id: str, response: Response) -> Dict[str, Any]:
     code, r = await fetch_func(query=drama_id, t="drama")
 
@@ -43,7 +73,13 @@ async def fetch(drama_id: str, response: Response) -> Dict[str, Any]:
     return r
 
 
-@app.get("/id/{drama_id}/cast")
+@app.get(
+    "/id/{drama_id}/cast",
+    response_model=CastResponse,
+    tags=["drama"],
+    summary="Drama full cast",
+    responses=_error_responses,
+)
 async def fetch_cast(drama_id: str, response: Response) -> Dict[str, Any]:
     code, r = await fetch_func(query=f"{drama_id}/cast", t="cast")
 
@@ -51,7 +87,13 @@ async def fetch_cast(drama_id: str, response: Response) -> Dict[str, Any]:
     return r
 
 
-@app.get("/id/{drama_id}/episodes")
+@app.get(
+    "/id/{drama_id}/episodes",
+    response_model=EpisodesResponse,
+    tags=["drama"],
+    summary="Drama episodes",
+    responses=_error_responses,
+)
 async def fetch_episodes(drama_id: str, response: Response) -> Dict[str, Any]:
     code, r = await fetch_func(query=f"{drama_id}/episodes", t="episodes")
 
@@ -59,7 +101,13 @@ async def fetch_episodes(drama_id: str, response: Response) -> Dict[str, Any]:
     return r
 
 
-@app.get("/id/{drama_id}/reviews")
+@app.get(
+    "/id/{drama_id}/reviews",
+    response_model=ReviewsResponse,
+    tags=["drama"],
+    summary="Drama reviews",
+    responses=_error_responses,
+)
 async def fetch_reviews(
     drama_id: str, response: Response, page: int = 1
 ) -> Dict[str, Any]:
@@ -69,7 +117,27 @@ async def fetch_reviews(
     return r
 
 
-@app.get("/people/{person_id}")
+@app.get(
+    "/id/{drama_id}/photos",
+    response_model=PhotosResponse,
+    tags=["drama"],
+    summary="Drama photos",
+    responses=_error_responses,
+)
+async def fetch_drama_photos(drama_id: str, response: Response) -> Dict[str, Any]:
+    code, r = await fetch_func(query=f"{drama_id}/photos", t="photos")
+
+    response.status_code = code
+    return r
+
+
+@app.get(
+    "/people/{person_id}",
+    response_model=PersonResponse,
+    tags=["people"],
+    summary="Person details",
+    responses=_error_responses,
+)
 async def person(person_id: str, response: Response) -> Dict[str, Any]:
     code, r = await fetch_func(query=f"people/{person_id}", t="person")
 
@@ -77,7 +145,27 @@ async def person(person_id: str, response: Response) -> Dict[str, Any]:
     return r
 
 
-@app.get("/dramalist/{user_id}")
+@app.get(
+    "/people/{person_id}/photos",
+    response_model=PhotosResponse,
+    tags=["people"],
+    summary="Person photos",
+    responses=_error_responses,
+)
+async def fetch_person_photos(person_id: str, response: Response) -> Dict[str, Any]:
+    code, r = await fetch_func(query=f"people/{person_id}/photos", t="photos")
+
+    response.status_code = code
+    return r
+
+
+@app.get(
+    "/dramalist/{user_id}",
+    response_model=DramalistResponse,
+    tags=["user"],
+    summary="User drama list",
+    responses=_error_responses,
+)
 async def dramalist(user_id: str, response: Response) -> Dict[str, Any]:
     code, r = await fetch_func(query=f"dramalist/{user_id}", t="dramalist")
 
@@ -85,7 +173,13 @@ async def dramalist(user_id: str, response: Response) -> Dict[str, Any]:
     return r
 
 
-@app.get("/list/{list_id}")
+@app.get(
+    "/list/{list_id}",
+    response_model=ListResponse,
+    tags=["list"],
+    summary="MDL curated list",
+    responses=_error_responses,
+)
 async def lists(list_id: str, response: Response) -> Dict[str, Any]:
     code, r = await fetch_func(query=f"list/{list_id}", t="lists")
 
@@ -93,27 +187,36 @@ async def lists(list_id: str, response: Response) -> Dict[str, Any]:
     return r
 
 
-# get seasonal drama list -- official api available, use it with cloudflare bypass
-@app.get("/seasonal/{year}/{quarter}")
-async def mdlSeasonal(year: int, quarter: int) -> Any:
-    # year -> ex. ... / 2019 / 2020 / 2021 / ...
-    # quarter -> every 3 months (Jan-Mar=1, Apr-Jun=2, Jul-Sep=3, Oct-Dec=4)
-    # --- seasonal information --- winter --- spring --- summer --- fall ---
-
+@app.get(
+    "/seasonal/{year}/{quarter}",
+    response_model=List[SeasonalDrama],
+    tags=["calendar"],
+    summary="Seasonal drama list",
+    description="Dramas airing in the given quarter. `quarter`: 1 = Jan–Mar · 2 = Apr–Jun · 3 = Jul–Sep · 4 = Oct–Dec.",
+)
+async def mdlSeasonal(year: int, quarter: int, response: Response) -> Any:
     client = primp.Client(impersonate="chrome", impersonate_os="linux")
 
-    return client.post(
-        "https://mydramalist.com/v1/quarter_calendar",
+    r = client.post(
+        "https://mydramalist.com/v1/calendar/quarter",
         data={"quarter": quarter, "year": year},
-    ).json()
+    )
+
+    response.status_code = r.status_code
+    return r.json()
 
 
-# get episode schedule
-@app.get("/schedule")
+@app.get(
+    "/schedule",
+    response_model=ScheduleResponse,
+    tags=["calendar"],
+    summary="Current week episode schedule",
+    description="Episode schedule for the current week, organised by day (0 = Monday … 6 = Sunday).",
+)
 async def mdlSchedule(response: Response) -> Any:
     client = primp.Client(impersonate="chrome", impersonate_os="linux")
 
-    r = client.post("https://mydramalist.com/v1/episode_calendar?lang=en-US")
+    r = client.post("https://mydramalist.com/v1/calendar/week")
 
     response.status_code = r.status_code
     return r.json()

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -1,0 +1,386 @@
+from datetime import datetime
+from typing import Any, Dict, List, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+# ─── Error ─────────────────────────────────────────────────────────────────────
+
+
+class ErrorDescription(BaseModel):
+    title: str
+    info: str
+
+
+class ErrorResponse(BaseModel):
+    error: bool = True
+    code: int
+    description: Union[str, ErrorDescription]
+
+
+# ─── Search ────────────────────────────────────────────────────────────────────
+
+
+class SearchDrama(BaseModel):
+    slug: str
+    thumb: str
+    mdl_id: Optional[str] = None
+    title: str = ""
+    ranking: Optional[str] = None
+    type: Optional[str] = None
+    year: Optional[int] = None
+    series: Union[str, bool] = False
+    rating: Optional[float] = None
+
+
+class SearchPerson(BaseModel):
+    slug: str
+    thumb: str
+    name: str
+    nationality: str
+
+
+class SearchResults(BaseModel):
+    dramas: List[SearchDrama] = []
+    people: List[SearchPerson] = []
+
+
+class SearchResponse(BaseModel):
+    query: str
+    results: SearchResults
+    scrape_date: datetime
+
+
+# ─── Shared ─────────────────────────────────────────────────────────────────────
+
+
+class CastPreview(BaseModel):
+    name: str
+    profile_image: str
+    slug: str
+    link: str
+
+
+class RelatedContentItem(BaseModel):
+    title: str
+    link: str
+    description: str
+    slug: str
+
+
+# ─── Drama ─────────────────────────────────────────────────────────────────────
+
+
+class DramaOthers(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    related_content: Optional[List[RelatedContentItem]] = None
+
+
+class DramaData(BaseModel):
+    link: str
+    title: str = ""
+    complete_title: str = ""
+    sub_title: Optional[str] = None
+    year: Optional[str] = None
+    rating: Union[float, str] = ""
+    poster: str = ""
+    synopsis: str = ""
+    casts: List[CastPreview] = []
+    next_episode_airing: Optional[Dict[str, Any]] = Field(
+        default=None,
+        description="Raw next-episode data from MDL's inline JS. Only present for currently airing dramas.",
+    )
+    current_episode: Optional[str] = None
+    details: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Dynamic key-value pairs from the drama detail sidebar (e.g. Native Title, Also Known As, Genres).",
+    )
+    others: Optional[DramaOthers] = Field(
+        default=None,
+        description="Additional metadata sections. Keys are dynamic (e.g. 'also_known_as', 'genres'). 'related_content' is always typed.",
+    )
+
+
+class DramaResponse(BaseModel):
+    slug_query: str
+    data: DramaData
+    scrape_date: datetime
+
+
+# ─── Cast ──────────────────────────────────────────────────────────────────────
+
+
+class CastRole(BaseModel):
+    name: Optional[str] = None
+    type: str = ""
+
+
+class CastMember(BaseModel):
+    name: str
+    profile_image: str
+    slug: str
+    link: str
+    role: Optional[CastRole] = None
+
+
+class CastData(BaseModel):
+    link: str
+    title: str = ""
+    poster: str = ""
+    casts: Dict[str, List[CastMember]] = Field(
+        default={},
+        description="Cast grouped by credit category (e.g. 'Main Role', 'Support Role', 'Director').",
+    )
+
+
+class CastResponse(BaseModel):
+    slug_query: str
+    data: CastData
+    scrape_date: datetime
+
+
+# ─── Episodes ──────────────────────────────────────────────────────────────────
+
+
+class Episode(BaseModel):
+    title: str
+    image: str
+    link: str
+    rating: str
+    air_date: Optional[str] = None
+
+
+class EpisodesData(BaseModel):
+    link: str
+    title: str = ""
+    episodes: List[Episode] = []
+
+
+class EpisodesResponse(BaseModel):
+    slug_query: str
+    data: EpisodesData
+    scrape_date: datetime
+
+
+# ─── Reviews ───────────────────────────────────────────────────────────────────
+
+
+class Reviewer(BaseModel):
+    name: str
+    user_link: str
+    user_image: str
+    info: str
+
+
+class ReviewRatings(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    overall: float = 0.0
+
+
+class Review(BaseModel):
+    reviewer: Reviewer
+    review: List[str] = []
+    ratings: ReviewRatings = Field(default_factory=ReviewRatings)
+
+
+class ReviewsData(BaseModel):
+    link: str
+    title: str = ""
+    poster: str = ""
+    reviews: List[Review] = []
+
+
+class ReviewsResponse(BaseModel):
+    slug_query: str
+    data: ReviewsData
+    scrape_date: datetime
+
+
+# ─── Photos ────────────────────────────────────────────────────────────────────
+
+
+class Photo(BaseModel):
+    link: str = Field(description="Link to the photo detail page on MDL.")
+    image: str = Field(description="Thumbnail URL (suffix _3m.jpg).")
+    full_image: str = Field(description="Full-size URL (suffix _3f.jpg).")
+
+
+class PhotosData(BaseModel):
+    link: str
+    title: Optional[str] = None
+    photos: List[Photo] = []
+
+
+class PhotosResponse(BaseModel):
+    slug_query: str
+    data: PhotosData
+    scrape_date: datetime
+
+
+# ─── Person ────────────────────────────────────────────────────────────────────
+
+
+class WorkTitle(BaseModel):
+    link: str
+    name: str
+
+
+class WorkRole(BaseModel):
+    name: Optional[str] = None
+    type: str = ""
+
+
+class WorkItem(BaseModel):
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    year: Union[int, str] = Field(description="Release year or 'TBA'.")
+    title: WorkTitle
+    rating: Union[float, str] = ""
+    role: Optional[WorkRole] = Field(
+        default=None, description="Character role. Present for actors."
+    )
+    type: Optional[str] = Field(
+        default=None, description="Credit type. Present for directors/writers."
+    )
+    episodes: Optional[int] = None
+
+
+class PersonData(BaseModel):
+    link: str
+    name: str = ""
+    about: str = ""
+    profile: str = ""
+    works: Dict[str, List[WorkItem]] = Field(
+        default={},
+        description="Works grouped by category (e.g. 'Drama', 'Movie', 'Special').",
+    )
+    details: Optional[Dict[str, str]] = Field(
+        default=None,
+        description="Dynamic key-value pairs from the person detail sidebar (e.g. Born, Nationality, Height).",
+    )
+
+
+class PersonResponse(BaseModel):
+    slug_query: str
+    data: PersonData
+    scrape_date: datetime
+
+
+# ─── DramaList ─────────────────────────────────────────────────────────────────
+
+
+class DramalistItem(BaseModel):
+    name: str
+    id: str
+    score: str
+    episode_seen: str
+    episode_total: str
+
+
+class DramalistCategory(BaseModel):
+    items: List[DramalistItem] = []
+    stats: Dict[str, str] = {}
+
+
+class DramalistData(BaseModel):
+    link: str
+    list: Dict[str, DramalistCategory] = Field(
+        default={},
+        description="Drama list grouped by watch status (e.g. 'Currently Watching', 'Completed', 'Dropped').",
+    )
+
+
+class DramalistResponse(BaseModel):
+    slug_query: str
+    data: DramalistData
+    scrape_date: datetime
+
+
+# ─── List ──────────────────────────────────────────────────────────────────────
+
+
+class ListShowItem(BaseModel):
+    title: str
+    image: str
+    rank: str = ""
+    url: str = ""
+    slug: Optional[str] = None
+    type: str
+    year: str
+    episodes: Optional[int] = None
+    short_summary: str = ""
+
+
+class ListPersonItem(BaseModel):
+    name: str
+    type: str
+    image: str
+    slug: str
+    url: str
+    nationality: str = ""
+    details: str = ""
+
+
+class ListData(BaseModel):
+    link: str
+    title: str = ""
+    description: str = ""
+    list: List[Union[ListPersonItem, ListShowItem]] = Field(
+        default=[],
+        description="List items. Each entry is either a show or a person. Person entries always carry type='person'.",
+    )
+
+
+class ListResponse(BaseModel):
+    slug_query: str
+    data: ListData
+    scrape_date: datetime
+
+
+# ─── Seasonal ──────────────────────────────────────────────────────────────────
+
+
+class SeasonalDrama(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: int
+    title: str
+    episodes: int
+    ranking: int
+    popularity: int
+    country: str
+    content_type: str
+    type: str
+    synopsis: str
+    released_at: str
+    url: str
+    genres: str
+    thumbnail: str
+    cover: str
+    rating: float
+    timezone: str
+    add_status: bool
+
+
+# ─── Schedule ──────────────────────────────────────────────────────────────────
+
+
+class ScheduleRelationship(BaseModel):
+    model_config = ConfigDict(extra="allow")
+
+    id: int
+    title: str
+
+
+class ScheduleResponse(BaseModel):
+    items: List[List[Any]] = Field(
+        description=(
+            "7 sublists indexed by day of the week (0 = Monday … 6 = Sunday). "
+            "Each entry references drama IDs from 'relationships'."
+        )
+    )
+    relationships: List[ScheduleRelationship] = Field(
+        description="Full drama objects referenced by the items lists."
+    )

--- a/app/utils.py
+++ b/app/utils.py
@@ -7,6 +7,7 @@ from app.handlers.fetch import (
     FetchEpisodes,
     FetchList,
     FetchPerson,
+    FetchPhotos,
     FetchReviews,
 )
 from app.handlers.search import Search
@@ -41,6 +42,7 @@ fs = {
     "lists": FetchList,
     "dramalist": FetchDramaList,
     "episodes": FetchEpisodes,
+    "photos": FetchPhotos,
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,10 @@ dependencies = [
 dev = ["mypy>=1.14.1", "pytest>=8.3.4", "ruff>=0.8.5"]
 
 
+[project.scripts]
+dev = "app:main"
+
+
 [tool.ruff]
 line-length = 88
 indent-width = 4


### PR DESCRIPTION
What's New

  Photos endpoints

  Added photo gallery scraping for both dramas and people. Each photo entry returns a thumbnail URL and a full-size URL (derived by replacing the _3m.jpg CDN
  suffix with _3f.jpg).

  GET /id/{mydramalist-slug}/photos
  GET /people/{people-id}/photos

  Fixed calendar endpoints

  The internal MDL API routes used by /seasonal and /schedule were dead. Both have been updated to the working endpoints:

  - /seasonal/{year}/{quarter} now calls POST /v1/calendar/quarter — also fixes a bug where errors from MDL were always returned as HTTP 200.
  - /schedule now calls POST /v1/calendar/week.

  Swagger / OpenAPI documentation

  All endpoints now expose typed Pydantic response models, fully visible in the Swagger UI at /docs. This includes:
  - Structured schemas for every response (drama, cast, episodes, reviews, photos, person, dramalist, list, seasonal, schedule).
  - Documented error responses (400/404) on all scraping routes.
  - Route tags, summaries and descriptions grouping endpoints by domain (drama, people, user, list, calendar, search).

  Developer experience

  Added a uv run dev script that starts the API with hot reload, replacing the more verbose uv run fastapi dev.
